### PR TITLE
When hovering on card highlight h3 instead of having to hover on h3

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -245,6 +245,11 @@ nav {
   	background-color: var(--background);
 }
 
+.website-card:hover > .card-info >  h3{
+	color: var(--primary);
+}
+
+
 .card-info {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
-- im not sure if having to hover on h3 is intentional or not but imo this is better --

instead of having this to hover on h3 like this,
https://github.com/zzznicob/stacksorted/assets/138622764/ab6d8521-02e0-4fb9-b878-d7e906f6b20c
it highlights when hovering on the actual card
https://github.com/zzznicob/stacksorted/assets/138622764/95d4a2c8-27f8-4453-ae36-ce1b4a1efb1a