### PR TITLE
Fix: Add overflow auto in image-bg css class to fix the image overflow issue (#34)

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -293,6 +293,7 @@ nav {
 	max-width: 100%;
 	max-height: 600px;
 	border-radius: 10px;
+	overflow: auto;
 }
 
 .outbound-cont {


### PR DESCRIPTION
### Issue
#34

### Description of Changes
In this pull request, I've addressed the modal overflow issue by setting the CSS property of images within the modal to "overflow: auto." This prevents images from overflowing their parent container and improves the user experience.

### Screenshots
![Screenshot 2023-10-08 000105](https://github.com/juxtopposed/stacksorted/assets/18514222/232bc1a6-a087-41cc-b682-6a16e0485aad)


### Checklist
- [x] Tested the changes locally and verified that the issue is resolved.
- [x] Checked for any potential side effects or regressions.

Please review and merge this pull request. Thank you!
