### PR TITLE
Update link for CodeDotSpirit Grid

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -508,7 +508,7 @@ export const websiteData = {
       },
       {
         name: "CodeDotSpirit",
-        url: "https://codedotspirit.dev/",
+        url: "https://old.codedotspirit.dev/",
         image: "/images/grids-10.webp",
         gif: "/images/grids-10g.webp ",
       },


### PR DESCRIPTION
This PR updates the link for the grid on the codedotspirit.dev website. I am going to re-release the website in a few days, but I feel like the grid was a cool UI element so I'm going to keep the old website up at https://old.codedotspirit.dev.

The reason I have not changed the buttons is that they are going to be on the new website as well.