### PR TITLE
Added A CodePen Link for Stripe Press

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1093,6 +1093,7 @@ export const websiteData = {
         url: "https://press.stripe.com/",
         image: "/images/3d-5.webp",
         gif: "/images/3d-5g.webp ",
+        code:"https://codepen.io/stranger1586/full/JojmzMx"
       },
       {
         name: "Dotlinecode",


### PR DESCRIPTION
This PR adds a [codepen](https://codepen.io/stranger1586/full/JojmzMx) link for the stripe press 3d entry.

![image](https://github.com/user-attachments/assets/b14ed829-d422-41c3-aa1f-fff4e333e064)
